### PR TITLE
Moves from docker.pkg.github.com to hub.docker.com (default)

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,0 +1,8 @@
+FROM continuumio/miniconda3:4.8.2
+
+LABEL authors="cgpu" \
+      description="Docker image containing dependencies for testing GH actions with conda and docker"
+
+COPY environment.yml /
+RUN conda env create -f /environment.yml && conda clean -a
+ENV PATH /opt/conda/envs/staries/bin:$PATH

--- a/.docker/environment.yml
+++ b/.docker/environment.yml
@@ -1,0 +1,8 @@
+name: staries
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - papermill=2.0.0
+  - jupytext=1.4.1
+  - nbdime=2.0.0

--- a/.github/workflows/export_conda_env.yml
+++ b/.github/workflows/export_conda_env.yml
@@ -18,6 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Check container
-        uses: docker://cgpu/papermill:2.0.0
+        uses: docker://cgpu/staries:1.0
         with:
           args: 'conda env export -n base'

--- a/.github/workflows/export_conda_env.yml
+++ b/.github/workflows/export_conda_env.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow from the Actions template
 
-name: hello-actions
+name: export-conda-env
 
 # Controls when the action will run (here whenever README.md is modified in the remote repo)
 # 
@@ -20,4 +20,4 @@ jobs:
       - name: Check container
         uses: docker://cgpu/papermill:2.0.0
         with:
-          args: 'conda env export -n papermill'
+          args: 'conda env export -n base'

--- a/.github/workflows/hello-actions.yml
+++ b/.github/workflows/hello-actions.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Check container
         uses: docker://cgpu/papermill:2.0.0
         with:
-          args: /bin/sh "echo 'Henlo GitHub Actions!'"
+          args: conda env export | grep -v "^prefix: "

--- a/.github/workflows/hello-actions.yml
+++ b/.github/workflows/hello-actions.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Check container
         uses: docker://cgpu/papermill:2.0.0
         with:
-          args: 'conda env export | grep -v "^prefix: "'
+          args: 'conda env export | grep -v ^prefix:'

--- a/.github/workflows/hello-actions.yml
+++ b/.github/workflows/hello-actions.yml
@@ -8,6 +8,8 @@ on:
   push:
     paths:
     - 'README.md'
+    - '.github/workflows/*.yml'
+    - '.github/workflows/*.yaml'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/hello-actions.yml
+++ b/.github/workflows/hello-actions.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Check container
         uses: docker://cgpu/papermill:2.0.0
         with:
-          args: 'conda env export | grep -v ^prefix:'
+          args: 'conda env export'

--- a/.github/workflows/hello-actions.yml
+++ b/.github/workflows/hello-actions.yml
@@ -1,0 +1,21 @@
+# This is a basic workflow from the Actions template
+
+name: hello-actions
+
+# Controls when the action will run (here whenever README.md is modified in the remote repo)
+# 
+on:
+  push:
+    paths:
+    - 'README.md'
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Check container
+        uses: docker.pkg.github.com/cgpu/staries/alpinegit:v2.24.1
+        with:
+          args: /bin/sh "echo 'Henlo GitHub Actions!'"

--- a/.github/workflows/hello-actions.yml
+++ b/.github/workflows/hello-actions.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Check container
         uses: docker://cgpu/papermill:2.0.0
         with:
-          args: conda env export | grep -v "^prefix: "
+          args: 'conda env export | grep -v "^prefix: "'

--- a/.github/workflows/hello-actions.yml
+++ b/.github/workflows/hello-actions.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Check container
         uses: docker://cgpu/papermill:2.0.0
         with:
-          args: 'conda env export'
+          args: 'conda env export -n papermill'

--- a/.github/workflows/hello-actions.yml
+++ b/.github/workflows/hello-actions.yml
@@ -16,6 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Check container
-        uses: docker.pkg.github.com/cgpu/staries/alpinegit:v2.24.1
+        uses: docker://cgpu/papermill:2.0.0
         with:
           args: /bin/sh "echo 'Henlo GitHub Actions!'"


### PR DESCRIPTION
Check this issuegit status; Cannot use docker.pkg.github.com docker containers
until login-less push/pull are allowed.