### PR TITLE
Updates gh-actions triggers

### DIFF
--- a/.github/workflows/getlibs.yml
+++ b/.github/workflows/getlibs.yml
@@ -1,8 +1,12 @@
 name: get-libs
-on: push
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+    paths:
+    - '**.R'
 jobs:
   linux:
-    if: contains(github.event.head_commit.message, '[get libs]') == true
+    if: contains(github.event.head_commit.message, '[skip libs]') == false
     strategy:
       matrix:
         r: [latest]

--- a/.github/workflows/hadolint_dockerfile.yml
+++ b/.github/workflows/hadolint_dockerfile.yml
@@ -1,5 +1,9 @@
-on: pull_request
 name: hadolint action
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
 jobs:
   hadolintOnPr:
     name: hadolint on pr

--- a/.github/workflows/lintr.yml
+++ b/.github/workflows/lintr.yml
@@ -1,24 +1,19 @@
 name: lintr
-on: [push, pull_request]
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+    paths:
+    - '**.R'
+
 jobs:
   linux:
     if: contains(github.event.head_commit.message, '[lint skip]') == false
     strategy:
       matrix:
-        r: [latest]
     runs-on: ubuntu-latest
-    container: rocker/tidyverse:${{ matrix.r }}
+    container: cgpu/lintr
     steps:
-    - uses: actions/checkout@v2
-    - name: Install apt-get dependencies
-      run: |
-        apt-get update
-        apt-get install git ssh curl bzip2 -y
-    - name: Install lintr
-      run: |
-        Rscript -e "install.packages('lintr', repos = 'https://cloud.r-project.org')"
-      shell:
-        bash
+    - uses: actions/checkout@v2.3.4
     - name: Running lintr
       run: |
         Rscript -e "lintr::lint_dir('./Rmdies/R')"

--- a/.github/workflows/reviewdog_hadolint.yml
+++ b/.github/workflows/reviewdog_hadolint.yml
@@ -1,7 +1,9 @@
 # From here: https://github.com/reviewdog/action-hadolint
 name: reviewdog hadolint
-on: [pull_request]
-jobs:
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
   hadolint:
     name: runner / hadolint
     runs-on: ubuntu-latest

--- a/.github/workflows/reviewdog_misspell.yml
+++ b/.github/workflows/reviewdog_misspell.yml
@@ -1,5 +1,8 @@
 name: reviewdog
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
 jobs:
   misspell:
     name: runner / misspell


### PR DESCRIPTION
## Overview

Updates GitHub action workflow triggers

## Purpose

Limit tests within an open PR context, minimize redundant triggers

## Changes

- Changes triggers from `push`,`pr` to only pr 
- Add context of files changed where applicable eg `.R` files 82a61dfa159f878c71f32dfa3d40fc8e478f2e9f


